### PR TITLE
Update Android project to use AndroidX support library

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,6 @@ ReactNativeViewPager_compileSdkVersion=28
 ReactNativeViewPager_buildToolsVersion=28.0.3
 ReactNativeViewPager_targetSdkVersion=27
 ReactNativeViewPager_minSdkVersion=16
+
+android.enableJetifier=true
+android.useAndroidX=true

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPager.java
@@ -7,8 +7,8 @@
 
 package com.reactnativecommunity.viewpager;
 
-import android.support.v4.view.PagerAdapter;
-import android.support.v4.view.ViewPager;
+import androidx.viewpager.widget.PagerAdapter;
+import androidx.viewpager.widget.ViewPager;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -134,7 +134,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    implementation "androidx.appcompat:appcompat:${rootProject.ext.supportLibVersion}"
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation project(':react-native-viewpager')

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 27
-        supportLibVersion = "28.0.0"
+        supportLibVersion = "1.0.2"
     }
     repositories {
         google()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -16,3 +16,6 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.enableJetifier=true
+android.useAndroidX=true


### PR DESCRIPTION
Use AndroidX in place of legacy Android support libraries. This is required for any Android projects that use AndroidX for support libraries.

See: https://developer.android.com/jetpack/androidx/migrate

Specifically react-native-gesture-handler currently has a 4 PRs to migrate to AndroidX being blocked by this down stream dependency for our tests that require this dependency.