### PR TITLE
Update RNCViewpager.podspec

### DIFF
--- a/RNCViewpager.podspec
+++ b/RNCViewpager.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
 
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNCViewpager.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/author/RNCViewpager.git", :tag => "v#{s.version}" }
   s.source_files  = "RNCViewpager/**/*.{h,m}"
   s.requires_arc = true
 


### PR DESCRIPTION
not a pods expert but I find it unlikely that `s.source` should point to "master".

If you look at other podspecs in the community they always refer to specific version.

huh, given that there is no ios support I guess this does not matter, but maybe once it will..? :)