### PR TITLE
fix: Remove childrenWithOverriddenStyle.

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -18,22 +18,6 @@ export const childrenWithOverriddenStyle = (children?: React.Node): Array<React.
     if (!child) {
       return null;
     }
-    const newProps = {
-      ...child.props,
-      style: [
-        child.props.style,
-        {
-          position: 'absolute',
-          left: 0,
-          top: 0,
-          right: 0,
-          bottom: 0,
-          width: undefined,
-          height: undefined,
-        },
-      ],
-      collapsable: false,
-    };
     if (
       child.type &&
       child.type.displayName &&
@@ -45,6 +29,6 @@ export const childrenWithOverriddenStyle = (children?: React.Node): Array<React.
         child.type.displayName,
       );
     }
-    return React.createElement(child.type, newProps);
+    return React.createElement(child.type, child.props);
   });
 };


### PR DESCRIPTION

# Summary
We don't need to override styles for each page. This should be handled outside the lib. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    ✅  |

## Checklist

- [x] I have tested this on a device and a simulator
