### PR TITLE
Remove delaying touches in ScrollView

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -287,6 +287,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
             if([subview isKindOfClass:UIScrollView.class]){
                 ((UIScrollView *)subview).delegate = self;
                 ((UIScrollView *)subview).keyboardDismissMode = _dismissKeyboard;
+                ((UIScrollView *)subview).delaysContentTouches = NO;
             }
         }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

In ViewPager previously touches in UIControl (Button from RNGH) were a bit delayed which is expected from one side (because gestures can negotiate better), but it's not used in React Native (in normal ScrollView) and leads to bad UX. 

Example: 
before:
https://streamable.com/f8doo
after:
https://streamable.com/457s3

## Test Plan

Install RNGH and add some button 

### What are the steps to reproduce?

Install RNGH and add some button 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |     ¯\_(ツ)_/¯      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
