### PR TITLE
Revert "Add overdrag property on iOS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ const styles = StyleSheet.create({
 |`orientation: Orientation`|Set `horizontal` or `vertical` scrolling orientation (it does **not** work dynamically)|both
 |`transitionStyle: TransitionStyle`|Use `scroll` or `curl` to change transition style (it does **not** work dynamically)|iOS
 |`showPageIndicator: boolean`|Shows the dots indicator at the bottom of the view|iOS
-|`overdrag: boolean`|Allows for overscrolling after reaching the end or very beginning or pages|iOS
 
 ## Preview
 

--- a/example/ViewPagerExample.js
+++ b/example/ViewPagerExample.js
@@ -36,7 +36,6 @@ type State = {
   pages: Array<CreatePage>,
   scrollState: PageScrollState,
   dotsVisible: boolean,
-  overdragEnabled: boolean,
 };
 
 export default class ViewPagerExample extends React.Component<*, State> {
@@ -61,7 +60,6 @@ export default class ViewPagerExample extends React.Component<*, State> {
       pages: pages,
       scrollState: 'idle',
       dotsVisible: false,
-      overdragEnabled: true,
     };
     this.viewPager = React.createRef();
   }
@@ -119,13 +117,7 @@ export default class ViewPagerExample extends React.Component<*, State> {
   };
 
   render() {
-    const {
-      page,
-      pages,
-      animationsAreEnabled,
-      dotsVisible,
-      overdragEnabled,
-    } = this.state;
+    const {page, pages, animationsAreEnabled, dotsVisible} = this.state;
     return (
       <SafeAreaView style={styles.container}>
         <ViewPager
@@ -141,8 +133,7 @@ export default class ViewPagerExample extends React.Component<*, State> {
           // Lib does not support dynamically transitionStyle change
           transitionStyle="scroll"
           showPageIndicator={dotsVisible}
-          ref={this.viewPager}
-          overdrag={overdragEnabled}>
+          ref={this.viewPager}>
           {pages.map(p => this.renderPage(p))}
         </ViewPager>
         <View style={styles.buttons}>
@@ -153,19 +144,6 @@ export default class ViewPagerExample extends React.Component<*, State> {
             }
             onPress={() =>
               this.setState({scrollEnabled: !this.state.scrollEnabled})
-            }
-          />
-          <Button
-            enabled={true}
-            text={
-              this.state.overdragEnabled
-                ? 'Overdrag Enabled'
-                : 'Overdrag Disabled'
-            }
-            onPress={() =>
-              this.setState(state => {
-                overdragEnabled: !state.overdragEnabled;
-              })
             }
           />
           <Button

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -182,7 +182,7 @@ PODS:
     - React-cxxreact (= 0.61.4)
     - React-jsi (= 0.61.4)
   - React-jsinspector (0.61.4)
-  - react-native-viewpager (3.1.0):
+  - react-native-viewpager (2.0.2):
     - React
   - React-RCTActionSheet (0.61.4):
     - React-Core/RCTActionSheetHeaders (= 0.61.4)
@@ -326,7 +326,7 @@ SPEC CHECKSUMS:
   React-jsi: ca921f4041505f9d5197139b2d09eeb020bb12e8
   React-jsiexecutor: 8dfb73b987afa9324e4009bdce62a18ce23d983c
   React-jsinspector: d15478d0a8ada19864aa4d1cc1c697b41b3fa92f
-  react-native-viewpager: 66c02e8a18d2d11eef08c84ed9a406b149791751
+  react-native-viewpager: 88f4269c19d626d2ccd5f7c7f5f7f76422ddb9e3
   React-RCTActionSheet: 7369b7c85f99b6299491333affd9f01f5a130c22
   React-RCTAnimation: d07be15b2bd1d06d89417eb0343f98ffd2b099a7
   React-RCTBlob: 8e0b23d95c9baa98f6b0e127e07666aaafd96c34

--- a/ios/ReactNativePageView.h
+++ b/ios/ReactNativePageView.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(strong, nonatomic, readonly) UIPageViewController *reactPageViewController;
 @property(strong, nonatomic, readonly) UIPageControl *reactPageIndicatorView;
 @property(nonatomic, readonly) RCTEventDispatcher *eventDispatcher;
-@property(nonatomic) BOOL overdrag;
 
 @property(nonatomic, strong) NSMutableArray<UIViewController *> *childrenViewControllers;
 @property(nonatomic) NSInteger initialPage;

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -32,7 +32,7 @@
                     coalescingKey:(uint16_t)coalescingKey;
 {
     RCTAssertParam(reactTag);
-
+    
     if ((self = [super init])) {
         _viewTag = reactTag;
         _position = position;
@@ -99,7 +99,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                     coalescingKey:(uint16_t)coalescingKey;
 {
     RCTAssertParam(reactTag);
-
+    
     if ((self = [super init])) {
         _viewTag = reactTag;
         _state = state;
@@ -165,7 +165,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                     coalescingKey:(uint16_t)coalescingKey;
 {
     RCTAssertParam(reactTag);
-
+    
     if ((self = [super init])) {
         _viewTag = reactTag;
         _position = position;
@@ -222,7 +222,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
         _dismissKeyboard = UIScrollViewKeyboardDismissModeNone;
         _coalescingKey = 0;
         _eventDispatcher = eventDispatcher;
-        _overdrag = YES;
     }
     return self;
 }
@@ -260,7 +259,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
         _childrenViewControllers = tempChildrenViewControllers;
         _reactPageIndicatorView.numberOfPages = _childrenViewControllers.count;
         [self goTo:[NSNumber numberWithInteger:_currentIndex] animated:NO];
-
+        
     } else {
         RCTLog(@"getParentViewController returns nil");
     }
@@ -272,17 +271,17 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                                  dictionaryWithObjectsAndKeys:
                                  [NSNumber numberWithLong:_pageMargin],
                                  UIPageViewControllerOptionInterPageSpacingKey, nil];
-
+        
         UIPageViewController *reactPageViewController =
         [[UIPageViewController alloc]
          initWithTransitionStyle:_transitionStyle
          navigationOrientation:_orientation
          options:options];
-
+        
         _reactPageViewController = reactPageViewController;
         _reactPageViewController.delegate = self;
         _reactPageViewController.dataSource = self;
-
+        
         for (UIView *subview in _reactPageViewController.view.subviews) {
             if([subview isKindOfClass:UIScrollView.class]){
                 ((UIScrollView *)subview).delegate = self;
@@ -290,19 +289,19 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                 ((UIScrollView *)subview).delaysContentTouches = NO;
             }
         }
-
+        
         [self renderChildrenViewControllers];
         _reactPageIndicatorView = [self createPageIndicator:self];
         _reactPageIndicatorView.hidden = !_showPageIndicator;
-
+    
         [[self reactViewController] addChildViewController:_reactPageViewController];
         [reactPageViewController.view addSubview:_reactPageIndicatorView];
         [self addSubview:reactPageViewController.view];
         _reactPageViewController.view.frame = [self bounds];
-
+        
         [_reactPageViewController didMoveToParentViewController:[self reactViewController]];
         [self shouldScroll:_scrollEnabled];
-
+        
         // Add the page view controller's gesture recognizers to the view controller's view so that the gestures are started more easily.
         self.gestureRecognizers = _reactPageViewController.gestureRecognizers;
         _reactPageIndicatorView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -343,7 +342,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
         [vc.view removeFromSuperview];
     }
     [_childrenViewControllers removeAllObjects];
-
+    
     for (UIView *view in [self reactSubviews]) {
         [view removeFromSuperview];
         UIViewController *pageViewController = [self createChildViewController:view];
@@ -374,7 +373,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
          if (weakSelf.eventDispatcher) {
              [weakSelf.eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:weakSelf.reactTag position:[NSNumber numberWithInteger:index] coalescingKey:coalescingKey]];
          }
-
+         
      }];
 }
 
@@ -387,20 +386,20 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 - (void)goTo:(NSNumber *)index animated:(BOOL)animated {
     if (_currentIndex >= 0 &&
         index.integerValue < _childrenViewControllers.count) {
-
+        
         _reactPageIndicatorView.currentPage = index.integerValue;
         UIPageViewControllerNavigationDirection direction =
         (index.integerValue > _currentIndex)
         ? UIPageViewControllerNavigationDirectionForward
         : UIPageViewControllerNavigationDirectionReverse;
-
+        
         UIViewController *viewController =
         [_childrenViewControllers objectAtIndex:index.integerValue];
         [self setReactViewControllers:index.integerValue
                                  with:viewController
                             direction:direction
                              animated:animated];
-
+        
     }
 }
 
@@ -426,7 +425,7 @@ willTransitionToViewControllers:
     UIViewController* currentVC = pageViewController.viewControllers[0];
     _currentIndex = [_childrenViewControllers indexOfObject:currentVC];
     [_eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] coalescingKey:_coalescingKey++]];
-
+    
     [_eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] offset:[NSNumber numberWithFloat:0] coalescingKey:_coalescingKey++]];
     _reactPageIndicatorView.currentPage = _currentIndex;
 }
@@ -437,13 +436,13 @@ willTransitionToViewControllers:
 (UIPageViewController *)pageViewController
        viewControllerAfterViewController:(UIViewController *)viewController {
     NSUInteger index = [_childrenViewControllers indexOfObject:viewController];
-
+    
     if (index == NSNotFound) {
         return nil;
     }
-
+    
     index++;
-
+    
     if (index == [_childrenViewControllers count]) {
         return nil;
     }
@@ -456,15 +455,15 @@ willTransitionToViewControllers:
 (UIPageViewController *)pageViewController
       viewControllerBeforeViewController:(UIViewController *)viewController {
     NSUInteger index = [_childrenViewControllers indexOfObject:viewController];
-
+    
     if (index == NSNotFound) {
         return nil;
     }
-
+    
     if (index == 0) {
         return nil;
     }
-
+    
     index--;
     return [_childrenViewControllers objectAtIndex:index];
 }
@@ -506,13 +505,6 @@ willTransitionToViewControllers:
 }
 
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset {
-    if (!_overdrag) {
-        if (_currentIndex == 0 && scrollView.contentOffset.x <= scrollView.bounds.size.width) {
-            *targetContentOffset = CGPointMake(scrollView.bounds.size.width, 0);
-        } else if (_currentIndex == _reactPageIndicatorView.numberOfPages-1 && scrollView.contentOffset.x >= scrollView.bounds.size.width) {
-            *targetContentOffset = CGPointMake(scrollView.bounds.size.width, 0);
-        }
-    }
     [_eventDispatcher sendEvent:[[RCTOnPageScrollStateChanged alloc] initWithReactTag:self.reactTag state:@"settling" coalescingKey:_coalescingKey++]];
 }
 
@@ -521,14 +513,6 @@ willTransitionToViewControllers:
 }
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    if (!_overdrag) {
-        if (_currentIndex == 0 && scrollView.contentOffset.x < scrollView.bounds.size.width) {
-            scrollView.contentOffset = CGPointMake(scrollView.bounds.size.width, 0);
-        } else if (_currentIndex == _reactPageIndicatorView.numberOfPages-1 && scrollView.contentOffset.x > scrollView.bounds.size.width) {
-            scrollView.contentOffset = CGPointMake(scrollView.bounds.size.width, 0);
-        }
-    }
-
     CGPoint point = scrollView.contentOffset;
     float offset = (point.x - self.frame.size.width)/self.frame.size.width;
     if(fabs(offset) > 1) {

--- a/ios/ReactViewPagerManager.m
+++ b/ios/ReactViewPagerManager.m
@@ -12,7 +12,6 @@ RCT_EXPORT_VIEW_PROPERTY(pageMargin, NSInteger)
 
 RCT_EXPORT_VIEW_PROPERTY(transitionStyle, UIPageViewControllerTransitionStyle)
 RCT_EXPORT_VIEW_PROPERTY(orientation, UIPageViewControllerNavigationOrientation)
-RCT_EXPORT_VIEW_PROPERTY(overdrag, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onPageSelected, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPageScroll, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPageScrollStateChanged, RCTDirectEventBlock)

--- a/js/types.js
+++ b/js/types.js
@@ -101,9 +101,4 @@ export type ViewPagerProps = $ReadOnly<{|
   orientation?: Orientation,
   transitionStyle?: TransitionStyle,
   showPageIndicator?: boolean,
-  /**
-   * Determines whether it's possible to overscroll a bit
-   * after reaching end or very beginning of pages.
-   */
-  overdrag?: boolean,
 |}>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -64,18 +64,13 @@ export interface ViewPagerProps extends ReactNative.ViewProps {
      * edge-to-edge.
      */
     pageMargin?: number;
-
+    
     /**
     * iOS only
     */
     orientation?: 'horizontal' | 'vertical',
     transitionStyle?: 'scroll' | 'curl',
     showPageIndicator?: boolean,
-    /**
-     * Determines whether it's possible to overscroll a bit
-     * after reaching end or very beginning of pages.
-     */
-    overdrag?: boolean,
 }
 
 declare class ViewPagerComponent extends React.Component<ViewPagerProps> {}


### PR DESCRIPTION
Reverts react-native-community/react-native-viewpager#107

It sometimes breaks on iOS. Pager stucks in the middle of the animation. Until I figure out what's wrong, I need to revert this

![image](https://user-images.githubusercontent.com/25709300/69650424-dee1ac00-106e-11ea-9a8e-95d3aaf2fed5.png)
