### PR TITLE
feat: add postinstall script.

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -53,3 +53,7 @@ target 'ViewPagerExample-tvOS' do
   end
 
 end
+
+post_install do |installer|
+  system('sh ./postinstall.sh')
+end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -182,7 +182,7 @@ PODS:
     - React-cxxreact (= 0.61.4)
     - React-jsi (= 0.61.4)
   - React-jsinspector (0.61.4)
-  - react-native-viewpager (3.1.0):
+  - react-native-viewpager (3.2.0):
     - React
   - React-RCTActionSheet (0.61.4):
     - React-Core/RCTActionSheetHeaders (= 0.61.4)
@@ -326,7 +326,7 @@ SPEC CHECKSUMS:
   React-jsi: ca921f4041505f9d5197139b2d09eeb020bb12e8
   React-jsiexecutor: 8dfb73b987afa9324e4009bdce62a18ce23d983c
   React-jsinspector: d15478d0a8ada19864aa4d1cc1c697b41b3fa92f
-  react-native-viewpager: 66c02e8a18d2d11eef08c84ed9a406b149791751
+  react-native-viewpager: 0cb7a533ce6e9ef0a48a5a7c8b3e3e3e345ae298
   React-RCTActionSheet: 7369b7c85f99b6299491333affd9f01f5a130c22
   React-RCTAnimation: d07be15b2bd1d06d89417eb0343f98ffd2b099a7
   React-RCTBlob: 8e0b23d95c9baa98f6b0e127e07666aaafd96c34
@@ -339,6 +339,6 @@ SPEC CHECKSUMS:
   ReactCommon: a6a294e7028ed67b926d29551aa9394fd989c24c
   Yoga: ba3d99dbee6c15ea6bbe3783d1f0cb1ffb79af0f
 
-PODFILE CHECKSUM: dc9b215313c32bd8b4ca7bafde7bc672c6f1e655
+PODFILE CHECKSUM: 98eccb3fcaa9f502392e0d71d9667549d78f02b5
 
 COCOAPODS: 1.8.4

--- a/example/ios/postinstall.sh
+++ b/example/ios/postinstall.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+dir=$(pwd)
+vpDir="$dir/Pods/react-native-viewpager/"
+localDir=$(cd ../../ios/ && pwd)
+cp -a $localDir $vpDir
+echo "copied files from $localDir to $vpDir"


### PR DESCRIPTION
# Summary
Cocoa pods does not support local dep, so I decided to copy local files inside `Pod` dir. 
Cocoapods will automatically link lib and postinstall script will copy files from `ios` to Pod dir.  

## Test Plan

* Make some changes inside `ios` file
* Check, if those changes are inside Pod file

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
