### PR TITLE
fix(ReactViewPager.java, ReactNativePageView.m): don't dispatch onPageSelected event when setting page programatically

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPager.java
@@ -200,7 +200,6 @@ public class ReactViewPager extends VerticalViewPager {
   public void setCurrentItemFromJs(int item, boolean animated) {
     mIsCurrentItemFromJs = true;
     setCurrentItem(item, animated);
-    mEventDispatcher.dispatchEvent(new PageSelectedEvent(getId(), item));
     mIsCurrentItemFromJs = false;
   }
 

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -370,10 +370,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
      animated:animated
      completion:^(BOOL finished) {
          weakSelf.currentIndex = index;
-         if (weakSelf.eventDispatcher) {
-             [weakSelf.eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:weakSelf.reactTag position:[NSNumber numberWithInteger:index] coalescingKey:coalescingKey]];
-         }
-         
      }];
 }
 


### PR DESCRIPTION
# Summary

Fixes https://github.com/react-native-community/react-native-viewpager/issues/129

This PR prevents the `onPageSelected` event from being triggered by calling `setPage` and `setPageWithoutAnimation`.

### What are the steps to reproduce (after prerequisites)?

```
useEffect(() => {
    pager.current && pager.current.setPageWithoutAnimation(activeIndex);
}, [activeIndex]);
```

```
<ViewPager
      ref={pager}
      pageMargin={0}
      onPageSelected={({ nativeEvent }) => setActiveIndex(nativeEvent.position)}
      style={[styles.pager, { width }]}
      initialPage={0}
>
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
