### PR TITLE
update index.d.ts to match flowtype

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,7 +14,7 @@ export interface PageScrollStateChangedEvent {
     pageScrollState: 'idle' | 'dragging' | 'settling';
 }
 
-export interface ViewPagerProps extends ReactNative.ViewProps {
+export interface ViewPagerProps {
     /**
      * Index of initial page that should be selected. Use `setPage` method to
      * update the page, and `onPageSelected` to monitor page changes
@@ -69,7 +69,20 @@ export interface ViewPagerProps extends ReactNative.ViewProps {
      */
     pageMargin?: number;
 
-    onMoveShouldSetResponderCapture?: (event: any) => boolean;
+    style: ReactNative.StyleProp<ReactNative.ViewStyle>
+
+    children: React.ReactChildren
+
+    /**
+     * If a parent `View` wants to prevent a child `View` from becoming responder
+     * on a move, it should have this handler which returns `true`.
+     *
+     * `View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`,
+     * where `event` is a synthetic touch event as described above.
+     *
+     * See http://facebook.github.io/react-native/docs/view.html#onMoveShouldsetrespondercapture
+     */
+    onMoveShouldSetResponderCapture?: (event: ReactNative.GestureResponderEvent) => boolean;
     
     /**
     * iOS only

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -69,9 +69,9 @@ export interface ViewPagerProps {
      */
     pageMargin?: number;
 
-    style: ReactNative.StyleProp<ReactNative.ViewStyle>
+    style?: ReactNative.StyleProp<ReactNative.ViewStyle>
 
-    children: React.ReactChildren
+    children?: React.ReactChildren
 
     /**
      * If a parent `View` wants to prevent a child `View` from becoming responder


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

fixes `index.d.ts` and removes `any` from the type.

The original `index.d.ts` had `ViewPager` extend `ViewProps`, but in the flow type, defined in https://github.com/react-native-community/react-native-viewpager/blob/master/js/types.js, it does not actually extend `ViewProps`, it only uses `ViewProps` to get the required type for `onMoveShouldSetResponderCapture`

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I updated the typed files (TS and Flow)
