### PR TITLE
[iOS] fix: crash on empty array

### DIFF
--- a/example/ViewPagerExample.js
+++ b/example/ViewPagerExample.js
@@ -87,6 +87,11 @@ export default class ViewPagerExample extends React.Component<*, State> {
     }));
   };
 
+  removeLastPage = () => {
+    this.setState(prevState => ({
+      pages: prevState.pages.slice(0, prevState.pages.length - 1),
+    }));
+  };
   move = (delta: number) => {
     const page = this.state.page + delta;
     this.go(page);
@@ -152,6 +157,11 @@ export default class ViewPagerExample extends React.Component<*, State> {
             onPress={this.toggleDotsVisibility}
           />
           <Button enabled={true} text="Add new page" onPress={this.addPage} />
+          <Button
+            enabled={true}
+            text="Remove last page"
+            onPress={this.removeLastPage}
+          />
         </View>
         <View style={styles.buttons}>
           {animationsAreEnabled ? (

--- a/example/src/component/ProgressBar.js
+++ b/example/src/component/ProgressBar.js
@@ -23,8 +23,13 @@ export class ProgressBar extends React.Component<Props> {
   render() {
     const fractionalPosition =
       this.props.progress.position + this.props.progress.offset;
-    const progressBarSize =
-      (fractionalPosition / (this.props.numberOfPages - 1)) * this.props.size;
+
+    let progressBarSize = this.props.size;
+    if (this.props.numberOfPages !== 1) {
+      progressBarSize =
+        (fractionalPosition / (this.props.numberOfPages - 1)) * this.props.size;
+    }
+
     return (
       <View style={[styles.progressBarContainer, {width: this.props.size}]}>
         <View style={[styles.progressBar, {width: progressBarSize}]} />

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -238,7 +238,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 }
 
 - (void)didUpdateReactSubviews {    
-    if (_childrenViewControllers.count == 0){
+    if (self.reactSubviews.count == 0) {
         return;
     }
     [self addPages];
@@ -384,7 +384,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 }
 
 - (void)goTo:(NSNumber *)index animated:(BOOL)animated {
-    if (_currentIndex >= 0) {
+    if (_currentIndex >= 0 && _currentIndex < _childrenViewControllers.count) {
         UIPageViewControllerNavigationDirection direction =
         (index.integerValue > _currentIndex)
         ? UIPageViewControllerNavigationDirectionForward


### PR DESCRIPTION
# Summary

When VP has no children, app crashed 

Close https://github.com/react-native-community/react-native-viewpager/issues/145

## Test Plan

Set initial page value to empty array like below: 
```
    this.state = {
      page: 0,
      pages: [],
    };
```
And app will crash 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ |
| Android |    ❌     |

## Checklist
- [x] I have tested this on a device and a simulator
