### PR TITLE
[iOS] fix: vertical scroll progress

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -511,7 +511,12 @@ willTransitionToViewControllers:
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
     CGPoint point = scrollView.contentOffset;
-    float offset = (point.x - self.frame.size.width)/self.frame.size.width;
+    float offset = 0;
+    if (_orientation == UIPageViewControllerNavigationOrientationHorizontal) {
+        offset = (point.x - self.frame.size.width)/self.frame.size.width;
+    } else {
+        offset = (point.y - self.frame.size.height)/self.frame.size.height;
+    }
     if(fabs(offset) > 1) {
         offset = offset > 0 ? 1.0 : -1.0;
     }


### PR DESCRIPTION
# Summary
Progress view display wrong value once user is scrolling vertically

Close https://github.com/react-native-community/react-native-viewpager/issues/127

## Test Plan

* Set orientation to vertical 
* Check, if progress bar displays correct value

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist
- [x] I have tested this on a device and a simulator
