### PR TITLE
fix: Set type on children as ReactNode in typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -69,9 +69,9 @@ export interface ViewPagerProps {
      */
     pageMargin?: number;
 
-    style?: ReactNative.StyleProp<ReactNative.ViewStyle>
+    style?: ReactNative.StyleProp<ReactNative.ViewStyle>;
 
-    children?: React.ReactChildren
+    children: React.ReactNode;
 
     /**
      * If a parent `View` wants to prevent a child `View` from becoming responder


### PR DESCRIPTION
# Summary

With the latest changes in typings (e12c183636f3b69c8e2408ccf82318b133034e74) as an attempt to match Flow and TypeScript, `ReactChildren` was used as children type. This is not the correct one, AFAIK. The typical children type is `ReactNode` which is defined as:

```ts
type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;
```

## Test Plan

This is a change in the typings and there are no proper test cases for this in the repo, but this has been tested in an actual project where the issue with mistypes occurred.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)


---

This PR Fixes #165 
