### PR TITLE
fix: prevent onPageSelected from firing too often on iOS

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -421,12 +421,14 @@ willTransitionToViewControllers:
         didFinishAnimating:(BOOL)finished
    previousViewControllers: (nonnull NSArray<UIViewController *> *)previousViewControllers
        transitionCompleted:(BOOL)completed {
-    UIViewController* currentVC = pageViewController.viewControllers[0];
-    _currentIndex = [_childrenViewControllers indexOfObject:currentVC];
-    [_eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] coalescingKey:_coalescingKey++]];
-    
-    [_eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] offset:[NSNumber numberWithFloat:0] coalescingKey:_coalescingKey++]];
-    _reactPageIndicatorView.currentPage = _currentIndex;
+    if (completed) {
+        UIViewController* currentVC = pageViewController.viewControllers[0];
+        _currentIndex = [_childrenViewControllers indexOfObject:currentVC];
+        [_eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] coalescingKey:_coalescingKey++]];
+
+        [_eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] offset:[NSNumber numberWithFloat:0] coalescingKey:_coalescingKey++]];
+        _reactPageIndicatorView.currentPage = _currentIndex;
+    }
 }
 
 #pragma mark - Datasource After


### PR DESCRIPTION
# Summary

Hi,

I realized on iOS `onPageSelected` can fire even when the transition is not completed.

Checking out [Apple documentation](https://developer.apple.com/documentation/uikit/uipageviewcontrollerdelegate/1614090-pageviewcontroller?language=objc), we should use the `completed` boolean to make sure the event fires only when transition is completed.

## Test Plan

### What's required for testing (prerequisites)?

The code below is enough to reproduce:

```js
const App = () => {
  return (
    <ViewPager
      style={styles.viewPager}
      initialPage={0}
      onPageSelected={({ nativeEvent: { position } }) => {
        alert(position);
      }}
    >
      <View key="1" style={{ backgroundColor: "yellow" }}>
        <Text style={{ fontSize: 30 }}>First page</Text>
      </View>
      <View key="2" style={{ backgroundColor: "blue" }}>
        <Text style={{ fontSize: 30 }}>Second page</Text>
      </View>
    </ViewPager>
  );
};
```

### What are the steps to reproduce (after prerequisites)?

Using the code above:

1. Reload JS

*Expected:* alert fires only once
*Actual:* alert fires twice

2. Swipe to second page but **before the transition is completed**, swipe back to first case

*Expected:* alert only displays `0` after coming back
*Actual:* alert displays `1` then `0`

| Before fix                 | After fix |
| ---------------------- | ----------------------|
| ![viewpager-complete-beforefix](https://user-images.githubusercontent.com/4534323/81475795-b1e51800-920e-11ea-8a11-4ac3afa368b0.gif) | ![viewpager-complete-afterfix](https://user-images.githubusercontent.com/4534323/81474906-c4f4e980-9208-11ea-8e57-7650d6abf069.gif) |

### onPageScroll

This fix also makes sure `offset + position` is always continuous

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅       |
| Android |    ✅ **(no changes, already works)**      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator (iPhone 11 simulator on XCode 11.4 + iPhone 7 device iOS 13.4.1) 
~- [ ] I added the documentation in `README.md`~ No documentation necessary
~- [ ] I mentioned this change in `CHANGELOG.md`~ No `changelog.md` in this repo
~- [ ] I updated the typed files (TS and Flow)~ No typing change
~- [ ] I added a sample use of the API in the example project (`example/App.js`)~ No api change
