### PR TITLE
perf: implement coalescing for onPageScroll on iOS

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -8,8 +8,7 @@
 
 - (instancetype) initWithReactTag:(NSNumber *)reactTag
                          position:(NSNumber *)position
-                           offset:(NSNumber *)offset
-                    coalescingKey:(uint16_t)coalescingKey;
+                           offset:(NSNumber *)offset;
 
 @end
 
@@ -17,7 +16,6 @@
 {
     NSNumber* _position;
     NSNumber* _offset;
-    uint16_t _coalescingKey;
 }
 
 @synthesize viewTag = _viewTag;
@@ -28,8 +26,7 @@
 
 - (instancetype) initWithReactTag:(NSNumber *)reactTag
                          position:(NSNumber *)position
-                           offset:(NSNumber *)offset
-                    coalescingKey:(uint16_t)coalescingKey;
+                           offset:(NSNumber *)offset;
 {
     RCTAssertParam(reactTag);
     
@@ -37,7 +34,6 @@
         _viewTag = reactTag;
         _position = position;
         _offset = offset;
-        _coalescingKey = coalescingKey;
     }
     return self;
 }
@@ -45,13 +41,13 @@
 RCT_NOT_IMPLEMENTED(- (instancetype)init)
 - (uint16_t)coalescingKey
 {
-    return _coalescingKey;
+    return 0;
 }
 
 
 - (BOOL)canCoalesce
 {
-    return NO;
+    return YES;
 }
 
 + (NSString *)moduleDotMethod
@@ -426,7 +422,7 @@ willTransitionToViewControllers:
         _currentIndex = [_childrenViewControllers indexOfObject:currentVC];
         [_eventDispatcher sendEvent:[[RCTOnPageSelected alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] coalescingKey:_coalescingKey++]];
 
-        [_eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] offset:[NSNumber numberWithFloat:0] coalescingKey:_coalescingKey++]];
+        [_eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] offset:[NSNumber numberWithFloat:0]]];
         _reactPageIndicatorView.currentPage = _currentIndex;
     }
 }
@@ -522,7 +518,7 @@ willTransitionToViewControllers:
     if(fabs(offset) > 1) {
         offset = offset > 0 ? 1.0 : -1.0;
     }
-    [_eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] offset:[NSNumber numberWithFloat:offset] coalescingKey:_coalescingKey++]];
+    [_eventDispatcher sendEvent:[[RCTOnPageScrollEvent alloc] initWithReactTag:self.reactTag position:[NSNumber numberWithInteger:_currentIndex] offset:[NSNumber numberWithFloat:offset]]];
 }
 
 @end


### PR DESCRIPTION
# Summary

Found inspiration in https://github.com/software-mansion/react-native-gesture-handler/pull/997:
This pull request implements event coalescing on `onPageScroll` event on iOS. 

Event coalescing is a built-in mechanism from React Native's event-emitter that merges several events together when events are generated faster on the native thread than they can be handled on the Javascript thread. This prevents accumulating lag when JS thread is under heavy load (or on low-end devices).

NB: coalescing is [the default on Android](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java#L56) so no changes on Android were required
This PR basically implements the same behavior on iOS.

## Test Plan

### What's required for testing (prerequisites)?

The code below uses the fibonacci function to simulate a busy JS thread
```js
function fibo(n: number): number {
  return n <= 2 ? n : fibo(n - 1) + fibo(n - 2);
}

const AnimatedViewPager = Animated.createAnimatedComponent(ViewPager);

const App = () => {
  const [text, setText] = useState(0);

  const scrollOffset = useRef(new Animated.Value(0)).current;
  const position = useRef(new Animated.Value(0)).current;

  return (
    <>
      <Text style={styles.text}>{text}</Text>
      <AnimatedViewPager
        style={styles.viewPager}
        initialPage={0}
        onPageScroll={Animated.event([{ nativeEvent: { offset: scrollOffset, position } }], {
          listener: ({ nativeEvent: { offset, position } }) => {
            fibo(35);
            setText(offset + position);
          },
          useNativeDriver: true,
        })}
      >
        <View key="1" style={{ backgroundColor: "yellow" }}>
          <Text style={{ fontSize: 30 }}>First page</Text>
        </View>
        <View key="2" style={{ backgroundColor: "blue" }}>
          <Text style={{ fontSize: 30 }}>Second page</Text>
        </View>
      </AnimatedViewPager>
    </>
  );
};
```

### What are the steps to reproduce (after prerequisites)?

Here are GIFs demonstrating before and after the fix:

| Before Fix      | After Fix |
| ------- | :---------: |
|![pager-beforecoalescing](https://user-images.githubusercontent.com/4534323/81506427-8e959800-92f6-11ea-9896-92cf9751ccbc.gif)|![pager-aftercoalescing](https://user-images.githubusercontent.com/4534323/81506433-981f0000-92f6-11ea-82fa-a2b731890806.gif)|

Without event coalescing, the text label continues to be updated long after the gesture is actually ended. With event coalescing, it stops updating as soon as the scrolling ends, since there is no event accumulation in the native thread's event-queue.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅ **(no changes required)**     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
