### PR TITLE
Fix UIViewControllerHierarchyInconsistency

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -375,7 +375,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (UIViewController *)createChildViewController:(UIView *)view {
     UIViewController *childViewController = [[UIViewController alloc] init];
-    childViewController.view = view;
+    [childViewController.view addSubview: view];
     return childViewController;
 }
 


### PR DESCRIPTION
Fixes app crash because of UIViewControllerHierarchyInconsistency

[issue](https://github.com/react-native-community/react-native-viewpager/issues/167)

Tested on simulator and real device
