### PR TITLE
fix(ios): hide/show indicator once orientation changed

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -228,6 +228,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
         [self shouldScroll:_scrollEnabled];
         //Below line fix bug, where the view does not update after orientation changed.
         [self goTo:@(_currentIndex) animated:NO];
+        [self shouldShowPageIndicator:_showPageIndicator];
     } else {
         [self embed];
     }
@@ -471,6 +472,17 @@ willTransitionToViewControllers:
     _showPageIndicator = showPageIndicator;
     if (_reactPageIndicatorView){
         _reactPageIndicatorView.hidden = !showPageIndicator;
+    }
+    
+    // https://github.com/react-native-community/react-native-viewpager/issues/182
+    if (_transitionStyle == UIPageViewControllerTransitionStylePageCurl) {
+        NSArray *subviews = self.reactPageViewController.view.subviews;
+        for (int i=0; i<[subviews count]; i++) {
+            if ([[subviews objectAtIndex:i] isKindOfClass:[UIPageControl class]]) {
+                NSInteger numberOfPages = _showPageIndicator ? _childrenViewControllers.count : 0;
+                ((UIPageControl *)[subviews objectAtIndex:i]).numberOfPages = numberOfPages;
+            }
+        }
     }
 }
 

--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -477,10 +477,10 @@ willTransitionToViewControllers:
     // https://github.com/react-native-community/react-native-viewpager/issues/182
     if (_transitionStyle == UIPageViewControllerTransitionStylePageCurl) {
         NSArray *subviews = self.reactPageViewController.view.subviews;
-        for (int i=0; i<[subviews count]; i++) {
-            if ([[subviews objectAtIndex:i] isKindOfClass:[UIPageControl class]]) {
+        for (UIView *view in subviews) {
+            if ([view isKindOfClass:[UIPageControl class]]) {
                 NSInteger numberOfPages = _showPageIndicator ? _childrenViewControllers.count : 0;
-                ((UIPageControl *)[subviews objectAtIndex:i]).numberOfPages = numberOfPages;
+                ((UIPageControl *)view).numberOfPages = numberOfPages;
             }
         }
     }


### PR DESCRIPTION
# Summary

When orientation changed, page indicator did not behave in correct way. Instead of be hidden, it was displayed on the screen. Initially in portrait mode indicator was not displayed, but in landscape mode, when orientation changed, indicator was displayed. It should be hidden all the time, unless `showPageIndicator` is set to `true`. 

I noticed, in curl mode `setHidden` does not work. I could find any reliable solution for it and I hacked a little bit VP. 

Closes https://github.com/react-native-community/react-native-viewpager/issues/182

## Test Plan

* set ` transitionStyle="curl"`
* rotate the screen 
* check, if dots are hidden 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ❌     |

## Checklist

- [x] I have tested this on a device and a simulator
