### PR TITLE
fix: Android ReactViewpagerManager destroys wrong Views

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/viewpager/FragmentAdapter.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/FragmentAdapter.java
@@ -11,6 +11,8 @@ import com.reactnative.community.viewpager2.adapter.FragmentStateAdapter;
 
 import java.util.ArrayList;
 
+import static com.reactnativecommunity.viewpager.ViewPagerFragment.CHILD_VIEW_KEY;
+
 public class FragmentAdapter extends FragmentStateAdapter {
 
     public FragmentAdapter(@NonNull FragmentActivity fragmentActivity) {
@@ -39,7 +41,8 @@ public class FragmentAdapter extends FragmentStateAdapter {
     public void removeFragment(View child) {
         for (int i = 0; i < children.size(); i++) {
             Fragment fragment = children.get(i);
-            if (fragment.getId() == child.getId()) {
+            int viewID = fragment.getArguments().getInt(CHILD_VIEW_KEY);
+            if (viewID == child.getId()) {
                 children.remove(i);
                 notifyItemRemoved(i);
                 return;
@@ -50,6 +53,16 @@ public class FragmentAdapter extends FragmentStateAdapter {
     public void removeFragmentAt(int index) {
         children.remove(index);
         notifyItemRemoved(index);
+    }
+
+
+    public void removeAll() {
+        children.clear();
+        notifyDataSetChanged();
+    }
+
+    public ArrayList<ViewPagerFragment> getChildren() {
+        return children;
     }
 
     public View getChildAt(int index) {

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -13,6 +13,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
 
@@ -37,6 +38,7 @@ import static com.reactnative.community.viewpager2.widget.ViewPager2.ORIENTATION
 import static com.reactnative.community.viewpager2.widget.ViewPager2.SCROLL_STATE_DRAGGING;
 import static com.reactnative.community.viewpager2.widget.ViewPager2.SCROLL_STATE_IDLE;
 import static com.reactnative.community.viewpager2.widget.ViewPager2.SCROLL_STATE_SETTLING;
+import static com.reactnativecommunity.viewpager.ViewPagerFragment.CHILD_VIEW_KEY;
 
 public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
 
@@ -125,10 +127,24 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
         ((FragmentAdapter) parent.getAdapter()).removeFragment(view);
     }
 
+
+    public void removeAllViews(ViewPager2 parent) {
+        FragmentAdapter adapter = ((FragmentAdapter) parent.getAdapter());
+        for (Fragment fragment : adapter.getChildren()) {
+            int viewID = fragment.getArguments().getInt(CHILD_VIEW_KEY);
+            reactChildrenViews.remove(viewID);
+        }
+        adapter.removeAll();
+        parent.setAdapter(null);
+    }
+
     @Override
     public void removeViewAt(ViewPager2 parent, int index) {
-        reactChildrenViews.removeAt(index);
-        ((FragmentAdapter) parent.getAdapter()).removeFragmentAt(index);
+        FragmentAdapter adapter = ((FragmentAdapter) parent.getAdapter());
+        Fragment fragment = adapter.getChildren().get(index);
+        int viewID = fragment.getArguments().getInt(CHILD_VIEW_KEY);
+        reactChildrenViews.remove(viewID);
+        adapter.removeFragmentAt(index);
     }
 
     @Override

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ViewPagerFragment.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ViewPagerFragment.java
@@ -11,7 +11,7 @@ import androidx.fragment.app.Fragment;
 
 public class ViewPagerFragment extends Fragment {
 
-    static String CHILD_VIEW_KEY = "CHILD_VIEW_KEY";
+    public static String CHILD_VIEW_KEY = "CHILD_VIEW_KEY";
 
     public static ViewPagerFragment newInstance(int id) {
         Bundle args = new Bundle();
@@ -27,5 +27,4 @@ public class ViewPagerFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         return ReactViewPagerManager.reactChildrenViews.get(getArguments().getInt(CHILD_VIEW_KEY));
     }
-
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Sometimes when navigating through an app and then returning to previous screens, the Viewpager can show blank pages. After bit of debugging on Java side, I noticed a bug that causes ReactViewpagerManager to discard wrong Views on calls to `removeView(Viewpager2, int)`. It uses the int as an index on the `reactChildrenViews` SparseArray it has directly, even though it should use it to find the correct child inside of that Viewpager2 parent parameter. So I changed it to properly do that child View lookup and then use the `removeView(Viewpager2, View)` method to do the actual View removal.

While fixing ReactViewpagerManager I also changed the `FragmentAdapter#getChildAt(int)` to also work on Fragments that haven't retrieved their View from ReactViewpagerManager yet, as otherwise my changes to ReactViewpagerManager would've started to cause memory leaks.

![viewpager-blank-page-bug](https://user-images.githubusercontent.com/4076467/86512269-3fa54400-be09-11ea-9b6c-548ae71adcdb.gif)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I've made a small project where the bug can be reproduced & issue goes away when these changes are applied: https://github.com/Pikkuninja/rn-viewpager-view-destroying-bug-repro. The README of that repo has instructions on how to reproduce the bug and a patch file for `patch-package` to quickly apply the fixes.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
