### PR TITLE
Add support for overScrollMode on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ const styles = StyleSheet.create({
 |`orientation: Orientation`|Set `horizontal` or `vertical` scrolling orientation (it does **not** work dynamically)|both
 |`transitionStyle: TransitionStyle`|Use `scroll` or `curl` to change transition style (it does **not** work dynamically)|iOS
 |`showPageIndicator: boolean`|Shows the dots indicator at the bottom of the view|iOS
+|`overScrollMode: OverScollMode`|Used to override default value of overScroll mode. Can be `auto`, `always` or `never`. Defaults to `auto`|Android
 
 ## Preview
 

--- a/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/ReactViewPagerManager.java
@@ -147,6 +147,17 @@ public class ReactViewPagerManager extends ViewGroupManager<ViewPager2> {
         viewPager.setOrientation(value.equals("vertical") ? ViewPager2.ORIENTATION_VERTICAL : ORIENTATION_HORIZONTAL);
     }
 
+    @ReactProp(name = "overScrollMode")
+    public void setOverScrollMode(ViewPager2 viewPager, String value) {
+        View child = viewPager.getChildAt(0);
+        if (value.equals("never")) {
+            child.setOverScrollMode(ViewPager2.OVER_SCROLL_NEVER);
+        } else if (value.equals("always")) {
+            child.setOverScrollMode(ViewPager2.OVER_SCROLL_ALWAYS);
+        } else {
+            child.setOverScrollMode(ViewPager2.OVER_SCROLL_IF_CONTENT_SCROLLS);
+        }
+    }
 
     @Override
     public Map getExportedCustomDirectEventTypeConstants() {

--- a/js/types.js
+++ b/js/types.js
@@ -43,6 +43,7 @@ export type PageSelectedEvent = SyntheticEvent<
 
 export type TransitionStyle = 'scroll' | 'curl';
 export type Orientation = 'horizontal' | 'vertical';
+export type OverScrollMode = 'auto' | 'always' | 'never';
 
 export type ViewPagerProps = $ReadOnly<{|
   /**
@@ -120,4 +121,8 @@ export type ViewPagerProps = $ReadOnly<{|
   orientation?: Orientation,
   transitionStyle?: TransitionStyle,
   showPageIndicator?: boolean,
+  /**
+   * Android only
+   */
+  overScrollMode?: OverScrollMode,
 |}>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -87,9 +87,9 @@ export interface ViewPagerProps {
     /**
     * iOS only
     */
-   orientation?: 'horizontal' | 'vertical',
-   transitionStyle?: 'scroll' | 'curl',
-   showPageIndicator?: boolean,
+    orientation?: 'horizontal' | 'vertical',
+    transitionStyle?: 'scroll' | 'curl',
+    showPageIndicator?: boolean,
     /**
     * Android only
     */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -87,9 +87,13 @@ export interface ViewPagerProps {
     /**
     * iOS only
     */
-    orientation?: 'horizontal' | 'vertical',
-    transitionStyle?: 'scroll' | 'curl',
-    showPageIndicator?: boolean,
+   orientation?: 'horizontal' | 'vertical',
+   transitionStyle?: 'scroll' | 'curl',
+   showPageIndicator?: boolean,
+    /**
+    * Android only
+    */
+   overScrollMode?: 'auto' | 'always' | 'never',
 }
 
 declare class ViewPagerComponent extends React.Component<ViewPagerProps> {}


### PR DESCRIPTION
# Summary

I think it's useful to expose this property. I find it important in my app where I don't want to have the overscoll shade visible. 


## Test Plan

https://streamable.com/ohupov

after setting `overScrollMode="never"`

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

try to scroll over the bounces. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
