### PR TITLE
fix: Android returning blank view when collection mutates

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/viewpager/FragmentAdapter.java
+++ b/android/src/main/java/com/reactnativecommunity/viewpager/FragmentAdapter.java
@@ -34,7 +34,7 @@ public class FragmentAdapter extends FragmentStateAdapter {
 
     public void addFragment(View child, int index) {
         children.add(ViewPagerFragment.newInstance(child.getId()));
-        notifyDataSetChanged();
+        notifyItemChanged(index);
     }
 
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
In Android, when component collection sent to the ViewPager mutates for some reason (eg. a list of questions in which the next question depends on the previous answer, see example below), the `ViewPagerFragment` will return an empty view.

### with current build
<img src="https://user-images.githubusercontent.com/17435926/88465461-78c95500-ce99-11ea-8e82-688aa1aa1cf9.gif" width="180" height="150">

### after changes
<img src="https://user-images.githubusercontent.com/17435926/88465497-db225580-ce99-11ea-9db0-32698ceb3404.gif" width="180" height="150"> 


## Test Plan

After a little debugging, I realized the observers weren't being notified of the change through `notifyDataSetChanged()`. As stated in [Android's documentation](https://developer.android.com/reference/kotlin/androidx/recyclerview/widget/RecyclerView.Adapter#notifydatasetchanged), it is more efficient to specify the event change.

> If you are writing an adapter it will always be more efficient to use the more specific change events if you can. Rely on notifyDataSetChanged() as a last resort.


## Compatibility

Impacts on Android only.
