### PR TITLE
fix(android): disable touchable view, when user swipes

### DIFF
--- a/js/ViewPager.js
+++ b/js/ViewPager.js
@@ -164,8 +164,6 @@ class ViewPager extends React.Component<ViewPagerProps> {
    * See https://github.com/react-native-community/react-native-viewpager/issues/164
    */
   _onMoveShouldSetResponderCapture = () => true;
-    return true;
-  };
 
   render() {
     return (

--- a/js/ViewPager.js
+++ b/js/ViewPager.js
@@ -83,8 +83,6 @@ function getViewManagerConfig(viewManagerName) {
  */
 
 class ViewPager extends React.Component<ViewPagerProps> {
-  isScrolling = false;
-
   componentDidMount() {
     // On iOS we do it directly on the native side
     if (Platform.OS === 'android') {
@@ -116,7 +114,6 @@ class ViewPager extends React.Component<ViewPagerProps> {
     if (this.props.onPageScrollStateChanged) {
       this.props.onPageScrollStateChanged(e);
     }
-    this.isScrolling = e.nativeEvent.pageScrollState === 'dragging';
   };
 
   _onPageSelected = (e: PageSelectedEvent) => {
@@ -162,11 +159,12 @@ class ViewPager extends React.Component<ViewPagerProps> {
     );
   };
 
-  _onMoveShouldSetResponderCapture = () => {
-    if (Platform.OS === 'ios') {
-      return this.isScrolling;
-    }
-    return false;
+  /**
+   * `ViewPager` wants to prevent a child `View` from becoming responder on a move
+   * See https://github.com/react-native-community/react-native-viewpager/issues/164
+   */
+  _onMoveShouldSetResponderCapture = (event) => {
+    return true;
   };
 
   render() {

--- a/js/ViewPager.js
+++ b/js/ViewPager.js
@@ -163,7 +163,7 @@ class ViewPager extends React.Component<ViewPagerProps> {
    * `ViewPager` wants to prevent a child `View` from becoming responder on a move
    * See https://github.com/react-native-community/react-native-viewpager/issues/164
    */
-  _onMoveShouldSetResponderCapture = (event) => {
+  _onMoveShouldSetResponderCapture = () => {
     return true;
   };
 

--- a/js/ViewPager.js
+++ b/js/ViewPager.js
@@ -163,7 +163,7 @@ class ViewPager extends React.Component<ViewPagerProps> {
    * `ViewPager` wants to prevent a child `View` from becoming responder on a move
    * See https://github.com/react-native-community/react-native-viewpager/issues/164
    */
-  _onMoveShouldSetResponderCapture = () => {
+  _onMoveShouldSetResponderCapture = () => true;
     return true;
   };
 


### PR DESCRIPTION
# Summary

close https://github.com/react-native-community/react-native-viewpager/issues/164

## Test Plan

* create list with touchable items 
* check, if touchable items will trigger onPress() when user scrolls

You can checkout on `164` branch and check, if it works.  

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅    |

## Checklist

- [x] I have tested this on a device and a simulator
